### PR TITLE
Added OLED_put_polygon routine together with its test

### DIFF
--- a/oled.h
+++ b/oled.h
@@ -276,3 +276,27 @@ OLED_err OLED_put_pixel(OLED *oled, uint8_t x, uint8_t y, bool pixel_state);
  * (!) Notice: method is not atomic. If required, protect it with lock
  */
 OLED_err OLED_put_rectangle(OLED *oled, uint8_t x_from, uint8_t y_from, uint8_t x_to, uint8_t y_to, enum OLED_params params);
+
+
+/**
+ * OLED_put_polygon() - draws a polygon
+ *
+ * @n_vert: number of vertices of polygon
+ * @x_axis: array of x coordinates
+ * @y_axis: array of y coordinates
+ * @params: parametes that difine color of the line and wheather the polygon should be filled or not
+ */
+OLED_err OLED_put_polygon(OLED *oled, uint8_t n, uint8_t *x_axis, uint8_t *y_axis, enum OLED_params params);
+
+
+/**
+ * point_in_polygon() - returns true if a point (x, y) is within a polygon or false otherwise.
+ * https://stackoverflow.com/questions/217578/how-can-i-determine-whether-a-2d-point-is-within-a-polygon
+ *
+ * @n_vert: number of vertices of polygon
+ * @x_axis: array of x coordinates
+ * @y_axis: array of y coordinates
+ * @x: x coorditate of a point of interest
+ * @y: y coorditate of a point of interest
+ */
+bool point_in_polygon(uint8_t n_vert, uint8_t *x_axis, uint8_t *y_axis, uint8_t x, uint8_t y);

--- a/oled_test_poly.c
+++ b/oled_test_poly.c
@@ -1,0 +1,37 @@
+#define F_CPU 16000000UL
+
+#include "oled.h"
+#include <avr/io.h>
+
+
+int main()
+{
+
+	sei();
+	OLED oled;
+	uint8_t fb[1024] = {0};
+	OLED_init(&oled, 128, 64, fb, 200000, 0b0111100);
+
+	/* Try to decrease frequency and see what happens without lock */
+	OLED_WITH_SPINLOCK(&oled) {
+	  	OLED_put_rectangle(&oled, 0, 0, 127, 63, OLED_FILL | OLED_BLACK);
+	}
+
+    /* 8 vertice polygon */
+    uint8_t x_axis[] = {20, 30, 90, 80, 80, 70, 10, 20};
+    uint8_t y_axis[] = {10, 5, 5, 10, 50, 55, 55, 50};
+    /* rectangle */
+    uint8_t x_axis2[] = {10, 100, 100, 10};
+    uint8_t y_axis2[] = {10, 10, 50, 50};
+    /* triangle */
+    uint8_t x_axis3[] = {30, 80, 70};
+    uint8_t y_axis3[] = {30, 30, 10};
+
+    OLED_put_polygon(&oled, 8, x_axis, y_axis, OLED_FILL | OLED_WHITE);
+    OLED_put_polygon(&oled, 4, x_axis2, y_axis2, OLED_NO_FILL | OLED_WHITE);
+    OLED_put_polygon(&oled, 3, x_axis3, y_axis3, OLED_FILL | OLED_BLACK);
+
+	while (1) {
+		OLED_refresh(&oled);
+	}
+}


### PR DESCRIPTION
Added OLED_put_polygon routine to draw polygon. The polygon can be either filled or not, line weight is one pixel.
In order to test it, use oled_test_poly.c file. Note, that the function depends on OLED_put_line routing which isn't introduced here,  so you'll have to add it either as a separate dependency for the compiler or put straight to the oled.c file, the choice is up to you.