### PR TITLE
Added bitmask operations

### DIFF
--- a/oled.c
+++ b/oled.c
@@ -333,3 +333,56 @@ OLED_err OLED_put_rectangle(OLED *oled, uint8_t x_from, uint8_t y_from, uint8_t 
 
 	return OLED_EOK;
 }
+void OLED_put_masked_region(OLED *oled,uint8_t x,uint8_t y,uint8_t *region,uint8_t x_size_region,uint8_t y_size_region,enum OLED_mask flag){
+	if(y_size_region > 64 || x_size_region > 128)
+	return;
+
+	uint8_t remnant = 0;
+	if((y_size_region % 8)!= 0){
+
+		 	remnant = y_size_region % 8;
+			/* if y_size_region == 39, the remnant is 7.So we don't need to jump on new page for drawing. */
+			/* 4 pages will be enough (32/8) */
+			y_size_region = y_size_region - remnant ;
+			
+	}
+		
+	uint16_t byte_num = (y / 8) * (uint16_t)oled->width + x;
+	uint8_t page = y_size_region / 8;
+	/* Multiply by 128 to come back on the same place but page lower */
+	/* Replaces pixels from region to fb */
+	if (flag == 0)
+	{	for(uint8_t page_cnt = 0;page_cnt <page ; page_cnt++){ 
+			for(uint8_t i = 0; i< x_size_region;i++){
+			/* Multiply by 128 to come back on the same place but page lower */
+			oled->frame_buffer[byte_num+i+(page_cnt*128)] = region[i+(page_cnt*x_size_region)];
+			}
+		}	
+	}
+	/* Put pixels from region on fb using OR (adds)*/
+	if (flag == 1)
+	{	for(uint8_t page_cnt = 0;page_cnt <page ; page_cnt++){ 
+			for(uint8_t i = 0; i< x_size_region;i++){
+			oled->frame_buffer[byte_num+i+(page_cnt*128)] |= region[i+(page_cnt*x_size_region)];
+			}
+		}	
+	}
+	/* Put pixels from region on fb using NAND (subtracts) */
+	if (flag == 2)
+	{	for(uint8_t page_cnt = 0;page_cnt <page ; page_cnt++){ 
+			for(uint8_t i = 0; i< x_size_region;i++){
+			oled->frame_buffer[byte_num+i+(page_cnt*128)] &= ~region[i+(page_cnt*x_size_region)];
+			}
+		}	
+	}
+
+	/* Put pixels from region on fb using XOR (intersects) */
+	if(flag == 3)
+	{	for(uint8_t page_cnt = 0;page_cnt <page ; page_cnt++){ 
+			for(uint8_t i = 0; i< x_size_region;i++){
+			oled->frame_buffer[byte_num+i+(page_cnt*128)] ^= region[i+(page_cnt*x_size_region)];
+			}
+		}	
+	}
+	
+}

--- a/oled.h
+++ b/oled.h
@@ -291,9 +291,11 @@ OLED_err OLED_put_rectangle(OLED *oled, uint8_t x_from, uint8_t y_from, uint8_t 
 *   @region: the information(bytes) which you want to put in frame-buffer
 *   @x_size_region: width of the region
 *   @y_size_region: height of the region
-*   @flag: starts from 0 and ends with 3, used to configurate which operation *     with bytes will be made.
+*   @flag: starts from 0 and ends with 3, used to configurate which operation 
+*    with bytes will be made.
 *
-*   That function uses bitmask operations to put the region on the frame         *   buffer
+*   That function uses bitmask operations to put the region on the frame         
+*   buffer
 *
 */
 void OLED_put_masked_region(OLED *oled,uint8_t x,uint8_t y,uint8_t *region,uint8_t x_size_region,uint8_t y_size_region,enum OLED_mask flag);

--- a/oled.h
+++ b/oled.h
@@ -68,7 +68,15 @@ enum OLED_params {
 	OLED_NO_FILL = 0x00,		/* Do not fill the drawn area */
 	OLED_FILL = 0x02		/* Fill the area	      */
 };
+/* That structure is used in OLED_put_masked_region() as a flag */
+enum OLED_mask{
+    /* Each enum parameter corresponds bitmask operation */
+    OLED_REPLACE = 0,   /* fb=region */
+    OLED_ADD,           /* fb|=region */
+    OLED_SUBTRACT,      /* fb&=~region */  
+    OLED_INTERSECT      /* fb^=region */
 
+};
 /* Lock type. Need to be volatile to prevent optimizations */
 /* 1 means unlocked, 0 means locked */
 typedef volatile uint8_t	lock_t;
@@ -276,3 +284,17 @@ OLED_err OLED_put_pixel(OLED *oled, uint8_t x, uint8_t y, bool pixel_state);
  * (!) Notice: method is not atomic. If required, protect it with lock
  */
 OLED_err OLED_put_rectangle(OLED *oled, uint8_t x_from, uint8_t y_from, uint8_t x_to, uint8_t y_to, enum OLED_params params);
+/*  OLED_put_masked_region() - puts region of pixels on frame-buffer
+*   @oled: OLED object
+*   @x:		horizonal coordinate (starting at 0, left-to-right)
+*   @y:		vertical coordinate (starting at 0, top-to-bottom)
+*   @region: the information(bytes) which you want to put in frame-buffer
+*   @x_size_region: width of the region
+*   @y_size_region: height of the region
+*   @flag: starts from 0 and ends with 3, used to configurate which operation *     with bytes will be made.
+*
+*   That function uses bitmask operations to put the region on the frame         *   buffer
+*
+*/
+void OLED_put_masked_region(OLED *oled,uint8_t x,uint8_t y,uint8_t *region,uint8_t x_size_region,uint8_t y_size_region,enum OLED_mask flag);
+


### PR DESCRIPTION
Added ability to put region with bytes on the frame buffer.There are 4 different operations.
1.Replace 
2.Add (OR)
3.Substract (NAND)
4.Intersect (XOR)
Each(except first) of them corresponds to bitmask operation.
Be accurate with coordinates if you want the picture to be true. I've left the comments to the function for better understanding.
![photo_2018-08-18_18-49-31](https://user-images.githubusercontent.com/25767335/44300954-e5d02980-a317-11e8-8d06-e5dfa165a210.jpg)
